### PR TITLE
Wait for game to load before starting scripts

### DIFF
--- a/auto_clicker.js
+++ b/auto_clicker.js
@@ -45,4 +45,14 @@ function autoClicker() {
   }, 50); // The app hard-caps click attacks at 50
 }
 
-autoClicker();
+function waitForLoad(){
+    var timer = setInterval(function() {
+        if (!document.getElementById("game").classList.contains("loading")) {
+            // Check if the game window has loaded
+            clearInterval(timer);
+            autoClicker();
+        }
+    }, 200);
+}
+
+waitForLoad();

--- a/auto_hatchery.js
+++ b/auto_hatchery.js
@@ -84,4 +84,14 @@ function loopEggs() {
   }, 50); // Runs every game tick
 }
 
-loopEggs();
+function waitForLoad(){
+    var timer = setInterval(function() {
+        if (!document.getElementById("game").classList.contains("loading")) {
+            // Check if the game window has loaded
+            clearInterval(timer);
+            loopEggs();
+        }
+    }, 200);
+}
+
+waitForLoad();

--- a/auto_underground.js
+++ b/auto_underground.js
@@ -27,4 +27,14 @@ function loopMine() {
   }, 10000); // Every 10 seconds
 }
 
-loopMine();
+function waitForLoad(){
+    var timer = setInterval(function() {
+        if (!document.getElementById("game").classList.contains("loading")) {
+            // Check if the game window has loaded
+            clearInterval(timer);
+            loopMine();
+        }
+    }, 200);
+}
+
+waitForLoad();


### PR DESCRIPTION
The scripts hammer the console with errors because they call functions that don't exist until a save file is selected and the game is loaded. To prevent this, this change checks for the game to load before initializing the main loop. This check is performed by watching the 'game' div and waiting for the class 'loading' to be removed from that element.